### PR TITLE
Update release.yml to remove warnings

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,15 +22,15 @@ jobs:
     
       - name: get version
         id: version
-        uses: notiz-dev/github-action-json-property@7c8cf5cc36eb85d8d287a8086a39dac59628eb31
+        uses: zoexx/github-action-json-file-properties@b9f36ce6ee6fe2680cd3c32b2c62e22eade7e590
         with: 
-            path: "Packages/${{env.packageName}}/package.json"
+            file_path: "Packages/${{env.packageName}}/package.json"
             prop_path: "version"
     
       - name: Set Environment Variables
         run: |
-          echo "zipFile=${{ env.packageName }}-${{ steps.version.outputs.prop }}".zip >> $GITHUB_ENV
-          echo "unityPackage=${{ env.packageName }}-${{ steps.version.outputs.prop }}.unitypackage" >> $GITHUB_ENV
+          echo "zipFile=${{ env.packageName }}-${{ steps.version.outputs.value }}".zip >> $GITHUB_ENV
+          echo "unityPackage=${{ env.packageName }}-${{ steps.version.outputs.value }}.unitypackage" >> $GITHUB_ENV
         
       - name: Create Zip
         uses: thedoctor0/zip-release@09336613be18a8208dfa66bd57efafd9e2685657
@@ -49,7 +49,7 @@ jobs:
         
         
       - name: Make Release
-        uses: softprops/action-gh-release@1e07f4398721186383de40550babbdf2b84acfc5
+        uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844
         with:
           tag_name: ${{ steps.version.outputs.prop }}
           files: |


### PR DESCRIPTION
## Changes
- notiz-dev/github-action-json-property@7c8cf5cc36eb85d8d287a8086a39dac59628eb31 is still using node v12 and old set-output. It was replaced by zoexx/github-action-json-file-properties@b9f36ce6ee6fe2680cd3c32b2c62e22eade7e590
- softprops/action-gh-release@1e07f4398721186383de40550babbdf2b84acfc5 is still using old set-output. It was upgraded to softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844

## More Information
- Node v12 has been out of support since [April 2022](https://github.com/nodejs/Release/#end-of-life-releases), for more information: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/
- Old set-output are planned to fully disable them on 31st May 2023, for more information: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/