### PR TITLE
Correctly reference favicon.ico

### DIFF
--- a/Website/index.html
+++ b/Website/index.html
@@ -6,6 +6,7 @@
   <title>VCC Listing</title>
   <script type="module" src="https://unpkg.com/@fluentui/web-components"></script>
   <link rel="stylesheet" href="styles.css">
+  <link rel="icon" href="./favicon.ico">
 </head>
 <body>
   <div class="col align-items-center content">


### PR DESCRIPTION
Currently, the included favicon is not loaded by browsers because on GitHub pages all files (including favicon.ico) are on a sub path but browsers by default look at the domain root. Adding the proper metadata fixes this.