### PR TITLE
fix packageInfoVccUrlField (should be {{ listingInfo.Url }})

### DIFF
--- a/Website/index.html
+++ b/Website/index.html
@@ -148,7 +148,7 @@
         </div>
         <h5 class="m-0 mb-2">Listing URL</h5>
         <div class="row align-items-center">
-          <fluent-text-field aria-readonly="true" id="packageInfoVccUrlField" class="vccUrlField" readonly value="https://vrchat-community.github.io/template-package-listing/index.json">
+          <fluent-text-field aria-readonly="true" id="packageInfoVccUrlField" class="vccUrlField" readonly value="{{ listingInfo.Url }}">
           </fluent-text-field>
           <fluent-button class="ms-2" id="packageInfoVccUrlFieldCopy">
             <svg slot="start" width="20" height="20" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">


### PR DESCRIPTION
Currently, all websites that is using this template displays https://vrchat-community.github.io/template-package-listing/index.json in the Listing URL field in the info dialog.