### PR TITLE
Added support for automatic Unit Tests and Code Coverage Report generation.

### DIFF
--- a/.github/workflows/build-listing.yml
+++ b/.github/workflows/build-listing.yml
@@ -1,7 +1,6 @@
 name: Build Repo Listing
 
 env:
-  CurrentPackageName: com.vrchat.demo-template
   listPublishDirectory: Website
   pathToCi: ci
   
@@ -27,6 +26,7 @@ concurrency:
 
 jobs:
   
+  # Build the VPM Listing Website and deploy to GitHub Pages
   build-listing:
     name: build-listing
     environment:
@@ -35,34 +35,53 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       
-      - uses: actions/checkout@v3 # check out this repo
-      - uses: actions/checkout@v3 # check out automation repo
+      # Checkout Local Repository
+      - name: Checkout Local Repository
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744
+
+      # Checkout Automation Repository without removing prior checkouts
+      - name: Checkout Automation Repository
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744
         with:
           repository: vrchat-community/package-list-action
-          path: ${{env.pathToCi}}
-          clean: false # otherwise the local repo will no longer be checked out
-          
+          path: ${{ env.pathToCi }}
+          clean: false
+
+      # Download the lastest release from GitHub
+      - name: Download Latest Release
+        uses: robinraju/release-downloader@efa4cd07bd0195e6cc65e9e30c251b49ce4d3e51
+        with:
+          latest: true
+          fileName: "coverage.zip"          
+          extract: true
+          out-file-path: "Website/coverage"
+
+      # Load cached data from previous runs
       - name: Restore Cache
-        uses: actions/cache@v3
+        uses: actions/cache@f5ce41475b483ad7581884324a6eca9f48f8dcc7
         with:
           path: |
-            ${{env.pathToCi}}/.nuke/temp
+            ${{ env.pathToCi }}/.nuke/temp
             ~/.nuget/packages
           key: ${{ runner.os }}-${{ hashFiles('**/global.json', '**/*.csproj') }}
-          
+      
+      # Build Package Version Listing with Nuke
       - name: Build Package Version Listing
-        run: ${{env.pathToCi}}/build.cmd BuildRepoListing --root ${{env.pathToCi}} --list-publish-directory $GITHUB_WORKSPACE/${{env.listPublishDirectory}} --current-package-name ${{env.CurrentPackageName}}
+        run: ${{ env.pathToCi }}/build.cmd BuildRepoListing --root ${{ env.pathToCi }} --list-publish-directory $GITHUB_WORKSPACE/${{ env.listPublishDirectory }} --current-package-name ${{ vars.PACKAGE_NAME }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
- 
+
+      # Prepare for GitHub Pages deployment
       - name: Setup Pages
-        uses: actions/configure-pages@v3
-        
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/configure-pages@f156874f8191504dae5b037505266ed5dda6c382
+      
+      # Upload the VPM Listing Website to GitHub Pages artifacts
+      - name: Upload Pages Artifact
+        uses: actions/upload-pages-artifact@a753861a5debcf57bf8b404356158c8e1e33150c
         with:
-          path: ${{env.listPublishDirectory}}
-          
+          path: ${{ env.listPublishDirectory }}
+      
+      # Deploy the uploaded VPM Listing Website to GitHub Pages
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@f27bcc15848fdcdcc02f01754eb838e44bcf389b

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
         run: |
           echo "zipFile=${{ env.packageName }}-${{ steps.version.outputs.value }}".zip >> $GITHUB_ENV
           echo "unityPackage=${{ env.packageName }}-${{ steps.version.outputs.value }}.unitypackage" >> $GITHUB_ENV
-          echo "version=${{ steps.version.outputs.value }} >> $GITHUB_ENV"
+          echo "version=${{ steps.version.outputs.value }}" >> $GITHUB_ENV
         
       - name: Create Zip
         uses: thedoctor0/zip-release@09336613be18a8208dfa66bd57efafd9e2685657

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,15 +22,15 @@ jobs:
     
       - name: get version
         id: version
-        uses: notiz-dev/github-action-json-property@7c8cf5cc36eb85d8d287a8086a39dac59628eb31
+        uses: zoexx/github-action-json-file-properties@b9f36ce6ee6fe2680cd3c32b2c62e22eade7e590
         with: 
-            path: "Packages/${{env.packageName}}/package.json"
+            file_path: "Packages/${{env.packageName}}/package.json"
             prop_path: "version"
     
       - name: Set Environment Variables
         run: |
-          echo "zipFile=${{ env.packageName }}-${{ steps.version.outputs.prop }}".zip >> $GITHUB_ENV
-          echo "unityPackage=${{ env.packageName }}-${{ steps.version.outputs.prop }}.unitypackage" >> $GITHUB_ENV
+          echo "zipFile=${{ env.packageName }}-${{ steps.version.outputs.value }}".zip >> $GITHUB_ENV
+          echo "unityPackage=${{ env.packageName }}-${{ steps.version.outputs.value }}.unitypackage" >> $GITHUB_ENV
         
       - name: Create Zip
         uses: thedoctor0/zip-release@09336613be18a8208dfa66bd57efafd9e2685657
@@ -49,7 +49,7 @@ jobs:
         
         
       - name: Make Release
-        uses: softprops/action-gh-release@1e07f4398721186383de40550babbdf2b84acfc5
+        uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844
         with:
           tag_name: ${{ steps.version.outputs.prop }}
           files: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,7 @@ jobs:
         id: tag_version
         uses: rickstaa/action-create-tag@07b918ecbf94359b859f25f7a70553a84e804923
         with:
-          tag: ${{env.version}}
+          tag: "${{env.version}}"
         
       - name: Make Release
         uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,9 +2,6 @@ name: Build Release
 
 on: 
   workflow_dispatch:
-  push:
-    branches: main
-    paths: Packages/com.vrchat.demo-template/**
 
 env:
   packageName: "com.vrchat.demo-template"
@@ -46,13 +43,19 @@ jobs:
         with:
           package-path: ${{ env.unityPackage }}
           include-files: metaList
-        
+      
+      - name: Create Tag
+        id: tag_version
+        uses: mathieudutour/github-tag-action@86301c823dac64d427711dd6b99d7ffdd894d2dd
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          custom_tag: ${{ steps.version.outputs.prop }}
         
       - name: Make Release
         uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844
         with:
-          tag_name: ${{ steps.version.outputs.prop }}
           files: |
             ${{ env.zipFile }}
             ${{ env.unityPackage }}
             Packages/${{ env.packageName }}/package.json
+          tag_name: ${{ steps.version.outputs.prop }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,7 @@ jobs:
         run: |
           echo "zipFile=${{ env.packageName }}-${{ steps.version.outputs.value }}".zip >> $GITHUB_ENV
           echo "unityPackage=${{ env.packageName }}-${{ steps.version.outputs.value }}.unitypackage" >> $GITHUB_ENV
+          echo "version=${{ steps.version.outputs.value }} >> $GITHUB_ENV"
         
       - name: Create Zip
         uses: thedoctor0/zip-release@09336613be18a8208dfa66bd57efafd9e2685657
@@ -48,7 +49,7 @@ jobs:
         id: tag_version
         uses: rickstaa/action-create-tag@07b918ecbf94359b859f25f7a70553a84e804923
         with:
-          tag: ${{ steps.version.outputs.prop }}
+          tag: ${{env.version}}
         
       - name: Make Release
         uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844
@@ -57,4 +58,4 @@ jobs:
             ${{ env.zipFile }}
             ${{ env.unityPackage }}
             Packages/${{ env.packageName }}/package.json
-          tag_name: ${{ steps.version.outputs.prop }}
+          tag_name: ${{env.version}}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,10 +46,9 @@ jobs:
       
       - name: Create Tag
         id: tag_version
-        uses: mathieudutour/github-tag-action@86301c823dac64d427711dd6b99d7ffdd894d2dd
+        uses: rickstaa/action-create-tag@07b918ecbf94359b859f25f7a70553a84e804923
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          custom_tag: ${{ steps.version.outputs.prop }}
+          tag: ${{ steps.version.outputs.prop }}
         
       - name: Make Release
         uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,59 +3,182 @@ name: Build Release
 on: 
   workflow_dispatch:
 
-env:
-  packageName: "com.vrchat.demo-template"
-
-permissions:
-  contents: write
-
 jobs:
-  build:
+
+  # Validate Repository Configuration
+  config:
     runs-on: ubuntu-latest
+    outputs:
+      config_package: ${{ steps.config_package.outputs.configPackage }}
+      config_test: ${{ steps.config_test.outputs.configTest }}
     steps:
-    
+
+    # Ensure that required repository variable has been created for the Package
+    - name: Validate Package Config
+      id: config_package
+      run: |
+        if [ "${{ vars.PACKAGE_NAME }}" != "" ]; then
+          echo "configPackage=true" >> $GITHUB_OUTPUT;
+        else
+          echo "configPackage=false" >> $GITHUB_OUTPUT;
+        fi
+
+    # Ensure that required repository variables have been created for the Unit Tests
+    - name: Validate Test Config
+      id: config_test
+      run: |
+        if \
+        [ "${{ vars.ASSEMBLY_NAME }}" != "" ] && \
+        [ "${{ vars.REQUIRED_COVERAGE }}" != "" ] && \
+        [ "${{ vars.UNITY_VERSION }}" != "" ] && \
+        [ "${{ secrets.UNITY_EMAIL }}" != "" ] && \
+        [ "${{ secrets.UNITY_PASSWORD }}" != "" ] && \
+        [ "${{ secrets.UNITY_SERIAL }}" != "" ]; \
+        then
+          echo "configTest=true" >> $GITHUB_OUTPUT;
+        else
+          echo "configTest=false" >> $GITHUB_OUTPUT;
+        fi
+
+  # Optionally run Unit Tests
+  # If Unit Tests are not configured, this job will be skipped
+  test:
+    needs: config
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      checks: write
+    env:
+      coverageArtifactName: coverage
+    outputs:
+      coverage_artifact_name: ${{ env.coverageArtifactName }}
+    if: needs.config.outputs.config_package == 'true' && needs.config.outputs.config_test == 'true'
+    steps:
+      # Checkout Local Repository
       - name: Checkout
-        uses: actions/checkout@v3
-    
-      - name: get version
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744
+      
+      # Create a directory in which Code Coverage results can be stored
+      - name: Make Code Coverage Directory
+        run: mkdir -p CodeCoverage
+
+      # Run the Unit Tests and generate the Code Coverage report
+      - name: Test Runner
+        id: runner
+        uses: game-ci/unity-test-runner@9d0bc623a78ee101f2c8956460d73bba2dfcf0c4
+        env:
+          UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
+          UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
+          UNITY_SERIAL: ${{ secrets.UNITY_SERIAL }}
+        with:
+          githubToken: ${{ secrets.GITHUB_TOKEN }}
+          projectPath: Packages/${{ vars.PACKAGE_NAME }}
+          packageMode: true
+          unityVersion: ${{ vars.UNITY_VERSION }}
+          customParameters: -nographics -assemblyNames "${{ vars.ASSEMBLY_NAME }}.Tests;${{ vars.ASSEMBLY_NAME }}.Editor.Tests"
+          coverageOptions: 'generateBadgeReport;generateHtmlReport;assemblyFilters:+${{ vars.ASSEMBLY_NAME }},+${{ vars.ASSEMBLY_NAME }}.Editor'
+      
+      # Ensure that the Code Coverage report meets the user's configured requirements
+      - name: Enforce Code Coverage
+        uses: kemocade/Kemocade.Unity.Coverage.Action@ad06420f6fbb107bb3aa37f41fb99c79a3f93ad3
+        with:
+          coverage-file-path: ${{ steps.runner.outputs.coveragePath }}/Report/Summary.xml
+          required-coverage: ${{ vars.REQUIRED_COVERAGE }}
+
+      # Pass the Code Coverage report artifact onto the next job
+      - name: Upload Code Coverage Artifact
+        id: upload-coverage-artifact
+        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce
+        with:
+          name: ${{ env.coverageArtifactName }}
+          path: ${{ steps.runner.outputs.coveragePath }}/Report/
+
+  # Build and release the Package
+  # If the repository is not configured properly, this job will be skipped
+  build:
+    needs: [config, test]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    env:
+      packagePath: Packages/${{ vars.PACKAGE_NAME }}
+      codeCoveragePath: CodeCoverage
+      codeCoverageZipFile: coverage.zip
+    # Use always() to ensure this conditional is evaluated, even if the 'test' job is skipped
+    if: always() && needs.config.outputs.config_package == 'true'
+    steps:
+
+      # Checkout Local Repository
+      - name: Checkout
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744
+
+      # Create a directory in which Code Coverage results can be extracted
+      # This needs to be done even if there is no Code Coverage report
+      # Add an empty file so that the coverage.zip file can be released even without content
+      - name: Make Code Coverage Directory
+        run: |
+          mkdir -p "${{ env.codeCoveragePath }}"
+          touch "${{ env.codeCoveragePath }}/CODE_COVERAGE_HERE"
+      
+      # Download Code Coverage results if they exist
+      - name: Download Code Coverage Artifact
+        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
+        if: needs.test.outputs.coverage_artifact_name != ''
+        with:
+          name: "${{ needs.test.outputs.coverage_artifact_name }}"
+          path: "${{ env.codeCoveragePath }}"
+      
+      # Zip the Code Coverage results for release
+      # This needs to be done even if there is no Code Coverage report, so that the release will function downstream in the Build Listing workflow
+      - name: Create Code Coverage Zip
+        working-directory: "${{ env.codeCoveragePath }}"
+        run: zip -r "${{ github.workspace }}/${{ env.codeCoverageZipFile }}" .
+
+      # Get the Package version based on the package.json file
+      - name: Get Version
         id: version
         uses: zoexx/github-action-json-file-properties@b9f36ce6ee6fe2680cd3c32b2c62e22eade7e590
         with: 
-            file_path: "Packages/${{env.packageName}}/package.json"
+            file_path: "${{ env.packagePath }}/package.json"
             prop_path: "version"
     
+      # Configure the Environment Variables needed for releasing the Package
       - name: Set Environment Variables
         run: |
-          echo "zipFile=${{ env.packageName }}-${{ steps.version.outputs.value }}".zip >> $GITHUB_ENV
-          echo "unityPackage=${{ env.packageName }}-${{ steps.version.outputs.value }}.unitypackage" >> $GITHUB_ENV
+          echo "zipFile=${{ vars.PACKAGE_NAME }}-${{ steps.version.outputs.value }}".zip >> $GITHUB_ENV
+          echo "unityPackage=${{ vars.PACKAGE_NAME }}-${{ steps.version.outputs.value }}.unitypackage" >> $GITHUB_ENV
           echo "version=${{ steps.version.outputs.value }}" >> $GITHUB_ENV
-        
-      - name: Create Zip
-        uses: thedoctor0/zip-release@09336613be18a8208dfa66bd57efafd9e2685657
-        with:
-          type: "zip"
-          directory: "Packages/${{env.packageName}}/"
-          filename: "../../${{env.zipFile}}" # make the zip file two directories up, since we start two directories in above
-          
-      - run: find "Packages/${{env.packageName}}/" -name \*.meta >> metaList
-          
+
+      # Zip the Package for release
+      - name: Create Package Zip
+        working-directory: "${{ env.packagePath }}"
+        run: zip -r "${{ github.workspace }}/${{ env.zipFile }}" .
+      
+      # Build a list of .meta files for future use
+      - name: Track Package Meta Files
+        run: find "${{ env.packagePath }}/" -name \*.meta >> metaList
+      
+      # Make a UnityPackage version of the Package for release
       - name: Create UnityPackage
         uses: pCYSl5EDgo/create-unitypackage@cfcd3cf0391a5ef1306342794866a9897c32af0b
         with:
           package-path: ${{ env.unityPackage }}
           include-files: metaList
       
+      # Make a release tag of the version from the package.json file 
       - name: Create Tag
         id: tag_version
         uses: rickstaa/action-create-tag@07b918ecbf94359b859f25f7a70553a84e804923
         with:
-          tag: "${{env.version}}"
-        
+          tag: "${{ env.version }}"
+      
+      # Publish the Release to GitHub
       - name: Make Release
         uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844
         with:
           files: |
             ${{ env.zipFile }}
             ${{ env.unityPackage }}
-            Packages/${{ env.packageName }}/package.json
-          tag_name: ${{env.version}}
+            ${{ env.packagePath }}/package.json
+            ${{ env.codeCoverageZipFile }}
+          tag_name: ${{ env.version }}

--- a/Packages/com.vrchat.demo-template/Editor/ExampleEditorScript.cs
+++ b/Packages/com.vrchat.demo-template/Editor/ExampleEditorScript.cs
@@ -1,10 +1,13 @@
 ﻿using UnityEditor;
+using UnityEngine;
 
-public class ExampleEditorScript
+namespace VRChatPackageTemplate.Editor
 {
-    [MenuItem("Example Editor Script/Test")]
-    static void Test()
+    public class ExampleEditorScript
     {
-        EditorUtility.DisplayDialog("Example Script", "Opened This Dialog", "OK");
+        public const string MESSAGE = "Hello VRChat!";
+
+        [MenuItem("Example Editor Script/Test")]
+        public static void Test() => Debug.Log(MESSAGE);
     }
 }

--- a/Packages/com.vrchat.demo-template/Runtime.meta
+++ b/Packages/com.vrchat.demo-template/Runtime.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: df84107b27b1bb348b050ea8113fb1c2
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.vrchat.demo-template/Runtime/ExampleRuntimeScript.cs
+++ b/Packages/com.vrchat.demo-template/Runtime/ExampleRuntimeScript.cs
@@ -1,0 +1,10 @@
+﻿namespace VRChatPackageTemplate
+{
+    public static class ExampleRuntimeScript
+    {
+        public static int Add(int a, int b) => a + b;
+        public static int Subtract(int a, int b) => a - b;
+        public static int Multiply(int a, int b) => a * b;
+        public static int Divide(int a, int b) => a / b;
+    }
+}

--- a/Packages/com.vrchat.demo-template/Runtime/ExampleRuntimeScript.cs.meta
+++ b/Packages/com.vrchat.demo-template/Runtime/ExampleRuntimeScript.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 72a0cf66502843c4f9768562d2865f37
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.vrchat.demo-template/Runtime/VRChatPackageTemplate.asmdef
+++ b/Packages/com.vrchat.demo-template/Runtime/VRChatPackageTemplate.asmdef
@@ -1,0 +1,13 @@
+{
+    "name": "VRChatPackageTemplate",
+    "references": [],
+    "includePlatforms": [],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/Packages/com.vrchat.demo-template/Runtime/VRChatPackageTemplate.asmdef.meta
+++ b/Packages/com.vrchat.demo-template/Runtime/VRChatPackageTemplate.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 166069ed16541a04e8fac2ce7d535d84
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.vrchat.demo-template/Tests.meta
+++ b/Packages/com.vrchat.demo-template/Tests.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ec401bb758a02b14187f5b8b4ce30195
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.vrchat.demo-template/Tests/Editor.meta
+++ b/Packages/com.vrchat.demo-template/Tests/Editor.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 0353a71900354114a8821352fdef22a4
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.vrchat.demo-template/Tests/Editor/EditorTests.cs
+++ b/Packages/com.vrchat.demo-template/Tests/Editor/EditorTests.cs
@@ -1,0 +1,16 @@
+﻿using NUnit.Framework;
+using UnityEngine.TestTools;
+
+namespace VRChatPackageTemplate.Editor.Tests
+{
+    public class EditorTests
+    {
+        // Ensure that the Example Editor Script logs properly
+        [Test]
+        public void ExampleEditorTest()
+        {
+            ExampleEditorScript.Test();
+            LogAssert.Expect(UnityEngine.LogType.Log, ExampleEditorScript.MESSAGE);
+        }
+    }
+}

--- a/Packages/com.vrchat.demo-template/Tests/Editor/EditorTests.cs.meta
+++ b/Packages/com.vrchat.demo-template/Tests/Editor/EditorTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 52ade6da1190f594ab50f6ea84d2b6ad
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.vrchat.demo-template/Tests/Editor/VRChatPackageTemplate.Editor.Tests.asmdef
+++ b/Packages/com.vrchat.demo-template/Tests/Editor/VRChatPackageTemplate.Editor.Tests.asmdef
@@ -1,0 +1,23 @@
+{
+    "name": "VRChatPackageTemplate.Editor.Tests",
+    "references": [
+        "UnityEngine.TestRunner",
+        "UnityEditor.TestRunner",
+        "VRChatPackageTemplate.Editor"
+    ],
+    "includePlatforms": [
+        "Editor"
+    ],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [
+        "nunit.framework.dll"
+    ],
+    "autoReferenced": true,
+    "defineConstraints": [
+        "UNITY_INCLUDE_TESTS"
+    ],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/Packages/com.vrchat.demo-template/Tests/Editor/VRChatPackageTemplate.Editor.Tests.asmdef.meta
+++ b/Packages/com.vrchat.demo-template/Tests/Editor/VRChatPackageTemplate.Editor.Tests.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 5d77c7826df78fb45a862422d77c1414
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.vrchat.demo-template/Tests/Runtime.meta
+++ b/Packages/com.vrchat.demo-template/Tests/Runtime.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 79e9da6ed205d3b4bbbf86bcd29ff07c
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.vrchat.demo-template/Tests/Runtime/RuntimeTests.cs
+++ b/Packages/com.vrchat.demo-template/Tests/Runtime/RuntimeTests.cs
@@ -1,0 +1,26 @@
+﻿using NUnit.Framework;
+using System;
+using static NUnit.Framework.Assert;
+using static VRChatPackageTemplate.ExampleRuntimeScript;
+
+namespace VRChatPackageTemplate.Tests
+{
+    public class RuntimeTests
+    {
+        [Test]
+        public void TestAdd() => True(Add(5, 10) == 15);
+
+        [Test]
+        public void TestSubtract() => True(Subtract(5, 10) == -5);
+
+        [Test]
+        public void TestMultiply() => True(Multiply(25, 5) == 125);
+
+        [Test]
+        public void TestDivide() => True(Divide(25, 5) == 5);
+
+        [Test]
+        public void TestDivideByZero() =>
+            Throws<DivideByZeroException>(() => Divide(10, 0));
+    }
+}

--- a/Packages/com.vrchat.demo-template/Tests/Runtime/RuntimeTests.cs.meta
+++ b/Packages/com.vrchat.demo-template/Tests/Runtime/RuntimeTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: dd19931393f004b42980758062e7e2db
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.vrchat.demo-template/Tests/Runtime/VRChatPackageTemplate.Tests.asmdef
+++ b/Packages/com.vrchat.demo-template/Tests/Runtime/VRChatPackageTemplate.Tests.asmdef
@@ -1,0 +1,23 @@
+{
+    "name": "VRChatPackageTemplate.Tests",
+    "references": [
+        "UnityEngine.TestRunner",
+        "UnityEditor.TestRunner",
+        "VRChatPackageTemplate"
+    ],
+    "includePlatforms": [
+        "Editor"
+    ],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [
+        "nunit.framework.dll"
+    ],
+    "autoReferenced": true,
+    "defineConstraints": [
+        "UNITY_INCLUDE_TESTS"
+    ],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/Packages/com.vrchat.demo-template/Tests/Runtime/VRChatPackageTemplate.Tests.asmdef.meta
+++ b/Packages/com.vrchat.demo-template/Tests/Runtime/VRChatPackageTemplate.Tests.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: cf5815358935d9d43b756779f9f9bcd3
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.vrchat.demo-template/package.json
+++ b/Packages/com.vrchat.demo-template/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.vrchat.demo-template",
   "displayName": "VRChat Example Package",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "unity": "2019.4",
   "description": "Simple Package for testing Automation",
   "vrchatVersion": "2022.1.1",

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ to start a new GitHub project based on this template.
 ## 🚇 Migrating Assets Package
 Full details at [Converting Assets to a VPM Package](https://vcc.docs.vrchat.com/guides/convert-unitypackage)
 
-## Working on Your Package
+## ✏️ Working on Your Package
 
 * Delete the "Packages/com.vrchat.demo-template" directory or reuse it for your own package.
   * If you reuse the package, don't forget to rename it!
@@ -31,13 +31,13 @@ Full details at [Converting Assets to a VPM Package](https://vcc.docs.vrchat.com
 * When you're ready, commit and push your changes.
 * Once you've set up the automation as described below, you can easily publish new versions.
 
-## Setting up the Automation
+## 🤖 Setting up the Automation
 
-You'll need to make a change in [release.yml](.github/workflows/release.yml):
-* Change the `packageName` property on line 10 to include the name of your package, like `packageName: "com.vrchat.demo-template"`
+Create a repository variable with the name and value described below.
+For details on how to create repository variables, see [Creating Configuration Variables for a Repository](https://docs.github.com/en/actions/learn-github-actions/variables#creating-configuration-variables-for-a-repository).
+Make sure you are creating a **repository variable**, and not a **repository secret**.
 
-You'll also need to make a change to [build-listing.yml](.github/workflows/build-listing.yml):
-* Change `CurrentPackageName` in line 4 from `com.vrchat.demo-template` to your own package name.
+* `PACKAGE_NAME`: the name of your package, like `com.vrchat.demo-template`.
 
 Finally, go to the "Settings" page for your repo, then choose "Pages", and look for the heading "Build and deployment". Change the "Source" dropdown from "Deploy from a branch" to "GitHub Actions".
 
@@ -57,11 +57,77 @@ You can make a release by running the [Build Release](.github/workflows/release.
 
 Whenever you make a change to a release - manually publishing it, or manually creating, editing or deleting a release, the [Build Repo Listing](.github/workflows/build-listing.yml) action will make a new index of all the releases available, and publish them as a website hosted fore free on [GitHub Pages](https://pages.github.com/). This listing can be used by the VPM to keep your package up to date, and the generated index page can serve as a simple landing page with info for your package. The URL for your package will be in the format `https://username.github.io/repo-name`.
 
-## 🏠 Customizing the Landing Page
+## 🏠 Customizing the Landing Page (Optional)
 
 The action which rebuilds the listing also publishes a landing page. The source for this page is in `Website/index.html`. The automation system uses [Scriban](https://github.com/scriban/scriban) to fill in the objects like `{{ this }}` with information from the latest release's manifest, so it will stay up-to-date with the name, id and description that you provide there. You are welcome to modify this page however you want - just use the existing `{{ template.objects }}` to fill in that info wherever you like. The entire contents of your "Website" folder are published to your GitHub Page each time.
 
-## Technical Stuff
+## ⚙️ Automating Unit Tests (Optional)
+
+> :warning: **As of August 2023, Unity has ended support for offline activation of Personal Licenses.**
+> Due to this change, these steps to automate Unit Tests and generate Code Coverage on GitHub Actions will now only work with Unity Plus or Unity Pro Licenses.
+> You can still run Unit Tests manually from within the Unity Editor with a Personal License.
+
+Create repository variables with the names and values described below.
+Once again, make sure you are creating a **repository variable**, and not a **repository secret**.
+
+* `UNITY_VERSION`: The Unity Version to use for your build.
+  * Use the [current VRChat-compatible Unity Version](https://creators.vrchat.com/sdk/current-unity-version).
+  * As of August 2023, this version is `2019.4.31f1`.
+* `ASSEMBLY_NAME`: The Assembly name of your package.
+  * This is different than your package name. For example, this template package's assembly name is `VRChatPackageTemplate`, from `VRChatPackageTemplate.asmdef`.
+* `REQUIRED_COVERAGE`: The percentage of [Code Coverage](https://docs.unity3d.com/Packages/com.unity.testtools.codecoverage) (from 0 to 100) that you want to require before a release can be published.
+  * If you don't want to enforce any Code Coverage requirements, set this value to 0.
+
+Create repository secrets with the names and values described below.
+For details on how to create repository secrets, see [Creating Encrypted Secrets for a Repository](https://docs.github.com/en/actions/security-guides/encrypted-secrets#creating-encrypted-secrets-for-a-repository).
+This time, make sure you are creating **repository secrets**, and not **repository variables**.
+
+> :warning: **These secrets contain sensitive information that could compromise your Unity account if exposed!**
+> To keep them safe, you should only ever input these values as GitHub Actions encrypted secrets!
+> Never commit these secrets directly to source control!
+
+* `UNITY_EMAIL`: The email address associated with your Unity account.
+* `UNITY_PASSWORD`: The password for your Unity account.
+* `UNITY_SERIAL`: Your Unity Plus or Unity Pro serial number.
+  * For more information, see ["How do I find my license serial number?"](https://support.unity.com/hc/articles/209933966-How-do-I-find-my-license-serial-number).
+
+Ensure that your Tests and Test Assemblies match the locations and naming conventions from the [official Unity documentation](https://docs.unity3d.com/Manual/cus-tests.html), such as in these examples:
+* `Assets/Packages/<PACKAGE_NAME>/Tests/Editor/<ASSEMBLY_NAME>.Editor.Tests.asmdef`
+* `Assets/Packages/<PACKAGE_NAME>/Tests/Editor/<Your Tests Here>.cs`
+* `Assets/Packages/<PACKAGE_NAME>/Tests/Runtime/<ASSEMBLY_NAME>.Tests.asmdef`
+* `Assets/Packages/<PACKAGE_NAME>/Tests/Runtime/<Your Tests Here>.cs`
+
+If you only have Editor Tests or Runtime Tests, that's okay.
+You can safely delete the unused directory and its assembly definition.
+
+For more information on unit testing your VPM package, see ["Adding Tests to a Package"](https://docs.unity3d.com/Manual/cus-tests.html).
+
+## 📛 Setting up Badges (Optional)
+
+What is a GitHub Repository without cool [badges](https://shields.io/)?
+
+Once you have [published your repository's listing](#-rebuilding-the-listing) to GitHub Pages, you can use add a badge that displays your current VPM version:
+
+[![VPM Package Version](https://img.shields.io/vpm/v/com.vrchat.demo-template?repository_url=https%3A%2F%2Fdustuu.github.io%2Ftemplate-package%2Findex.json)](https://dustuu.github.io/template-package)
+
+In order to configure this badge for your repository instead of the original template repository, you will need to edit the two links within this badge as follows:
+* `https://img.shields.io/vpm/v/<PACKAGE_NAME>?repository_url=https%3A%2F%2F<GITHUB_USERNAME>.github.io%2F<REPOSITORY_NAME>%2Findex.json`
+* `https://<GITHUB_USERNAME>.github.io/<REPOSITORY_NAME>`
+
+If you have optionally [set up automatic unit tests](#%EF%B8%8F-automating-unit-tests-optional), you can also add a badge that displays your [code coverage results](https://docs.unity3d.com/Packages/com.unity.testtools.codecoverage):
+
+[![Code Coverage](https://dustuu.github.io/template-package/coverage/badge_linecoverage.svg)](https://dustuu.github.io/template-package/coverage)
+
+In order to configure this badge for your repository instead of the original template repository, you will need to edit the two links within this badge as follows:
+* `https://<GITHUB_USERNAME>.github.io/<REPOSITORY_NAME>/coverage/badge_linecoverage.svg`
+* `https://<GITHUB_USERNAME>.github.io/<REPOSITORY_NAME>/coverage`
+
+If you haven't set up automatic unit tests, you should remove this badge from your README file, as the source `.svg` image will not be generated.
+
+For both badges, if you repository is owned by an organization instead of an individual user, use your organization's name instead of `GITHUB_USERNAME`.
+It is recommended that you move these badges to the top of your README file, right underneath your repository title.
+
+## 💻 Technical Stuff
 
 You are welcome to make your own changes to the automation process to make it fit your needs, and you can create Pull Requests if you have some changes you think we should adopt. Here's some more info on the included automation:
 

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ In order to configure this badge for your repository instead of the original tem
 
 If you haven't set up automatic unit tests, you should remove this badge from your README file, as the source `.svg` image will not be generated.
 
-For both badges, if you repository is owned by an organization instead of an individual user, use your organization's name instead of `GITHUB_USERNAME`.
+For both badges, if your repository is owned by an organization instead of an individual user, use your organization's name instead of `GITHUB_USERNAME`.
 It is recommended that you move these badges to the top of your README file, right underneath your repository title.
 
 ## 💻 Technical Stuff

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ What is a GitHub Repository without cool [badges](https://shields.io/)?
 
 Once you have [published your repository's listing](#-rebuilding-the-listing) to GitHub Pages, you can use add a badge that displays your current VPM version:
 
-[![VPM Package Version](https://img.shields.io/vpm/v/com.vrchat.demo-template?repository_url=https%3A%2F%2Fdustuu.github.io%2Ftemplate-package%2Findex.json)](https://dustuu.github.io/template-package)
+[![VPM Package Version](https://img.shields.io/vpm/v/com.vrchat.demo-template?repository_url=https%3A%2F%2Fvrchat-community.github.io%2Ftemplate-package%2Findex.json)](https://vrchat-community.github.io/template-package)
 
 In order to configure this badge for your repository instead of the original template repository, you will need to edit the two links within this badge as follows:
 * `https://img.shields.io/vpm/v/<PACKAGE_NAME>?repository_url=https%3A%2F%2F<GITHUB_USERNAME>.github.io%2F<REPOSITORY_NAME>%2Findex.json`
@@ -116,7 +116,7 @@ In order to configure this badge for your repository instead of the original tem
 
 If you have optionally [set up automatic unit tests](#%EF%B8%8F-automating-unit-tests-optional), you can also add a badge that displays your [code coverage results](https://docs.unity3d.com/Packages/com.unity.testtools.codecoverage):
 
-[![Code Coverage](https://dustuu.github.io/template-package/coverage/badge_linecoverage.svg)](https://dustuu.github.io/template-package/coverage)
+[![Code Coverage](https://vrchat-community.github.io/template-package/coverage/badge_linecoverage.svg)](https://vrchat-community.github.io/template-package/coverage)
 
 In order to configure this badge for your repository instead of the original template repository, you will need to edit the two links within this badge as follows:
 * `https://<GITHUB_USERNAME>.github.io/<REPOSITORY_NAME>/coverage/badge_linecoverage.svg`


### PR DESCRIPTION
This pull request adds optional support for automatically running Unit Tests via GitHub Actions and generating Code Coverage Reports from those tests. Configuration steps for this feature are outlined [here](https://github.com/dustuu/template-package#%EF%B8%8F-automating-unit-tests-optional). If this feature is not configured by a user, it will simply be skipped over during workflow execution.

Two configurable [badges](https://shields.io/) have also been added to the README file; one badge which displays the package's current VPM version, and another which shows the results of the Code Coverage Report (if the new automatic unit tests feature is enabled). These badges are outlined [here](https://github.com/dustuu/template-package#-setting-up-badges-optional). When set up properly, they look like this:
* [![VPM Package Version](https://img.shields.io/vpm/v/com.vrchat.demo-template?repository_url=https%3A%2F%2Fdustuu.github.io%2Ftemplate-package-full%2Findex.json)](https://dustuu.github.io/template-package-full)
* [![Code Coverage](https://dustuu.github.io/template-package-full/coverage/badge_linecoverage.svg)](https://dustuu.github.io/template-package-full/coverage)

Clicking on the VPM badge opens the repository's VPM Listing Page, while clicking on the Code Coverage badge opens the the generated Code Coverage Report.

> :warning: **Note:**
> The Code Coverage badge currently does not render in my forked repository's README:
> [![Code Coverage](https://vrchat-community.github.io/template-package/coverage/badge_linecoverage.svg)](https://vrchat-community.github.io/template-package/coverage)
> This is because I have already changed it to point back to the source `vrchat-community/template-package` repository in preparation for being merged.
> If merged, this badge will render properly in the `vrchat-community/template-package` repository's README after the new `Build Release` workflow has been run at least one time with the Automatic Unit Tests feature enabled.
> Users who don't use the Automatic Unit Testing feature can simply remove this badge from their README files.    

Additionally, this pull request removes the need for users to manually edit any of the workflow files. It does this by using [repository variables](https://docs.github.com/en/actions/learn-github-actions/variables#creating-configuration-variables-for-a-repository) to pass values into the workflows. Users can now create a repository variable named `PACKAGE_NAME` with the name of their package, such as `com.vrchat.demo-template` in this demo, instead of manually editing the workflow files. This step has been added to the README file [here](https://github.com/dustuu/template-package#-setting-up-the-automation).

If automatic unit testing is enabled, [repository secrets](https://docs.github.com/en/actions/security-guides/encrypted-secrets#creating-encrypted-secrets-for-a-repository) can also be used for Unity License configuration, which are outlined [here](https://github.com/dustuu/template-package#%EF%B8%8F-automating-unit-tests-optional). There are also several more non-secret repository variables to be entered at this step.

In this template repository, these are the current configurations of all of the repository variables used:
| **Variable Name** | **Value** |
| - | - |
| `PACKAGE_NAME` | `com.vrchat.demo-template` |
| `ASSEMBLY_NAME` | `VRChatPackageTemplate` |
| `REQUIRED_COVERAGE` | `100` |
| `UNITY_VERSION` | `2019.4.31f1` |

If the user requests for Code Coverage percentages to be enforced by setting the `REQUIRED_COVERAGE` variable to something greater than `0`, the `Build Release` workflow will enforce their configured Code Coverage target. It does this by using my own custom fork of a GitHub Action that runs in a Docker Container: [Kemocade.Unity.Coverage.Action](https://github.com/kemocade/Kemocade.Unity.Coverage.Action). This Container is built during the start of the `Build Release` workflow's `test` job, and executed later in that same job's `Enforce Code Coverage` step.

The `Build Release` workflow previously only contained one job, `build`. It now contains three jobs: `config`, `test`, and `build`:

* `config`
  * Checks which [repository variables](https://docs.github.com/en/actions/learn-github-actions/variables#creating-configuration-variables-for-a-repository) and [repository secrets](https://docs.github.com/en/actions/security-guides/encrypted-secrets#creating-encrypted-secrets-for-a-repository) have been configured.
* `test`
  * Executes the [Game CI Test Runner](https://game.ci/docs/github/test-runner) GitHub Action and builds a Code Coverage report. If all required configuration was not found in the `config` job, this job will be skipped.
* `build`
  * Publishes a release of the package. This job only requires the `PACKAGE_NAME` variable to be configured, all other variables and secrets are optional. This job will run even if the `test` job is skipped.

From this template repository, I've created 8 example repositories that show how the updated workflows respond to various possible configurations of repository variables, asset changes, or both:

* [template-package-unconfigured](https://github.com/dustuu/template-package-unconfigured) shows what happens when the workflows are run with no configuration.
  * Without a `PACKAGE_NAME` variable, the `Build Release` workflow will skip both the `test` and `build` jobs:
  * ![image](https://github.com/vrchat-community/template-package/assets/101824882/d5f75f1a-6e72-4ea0-bcca-c3f1c7f69141)
  * The `Build Repo Listing` workflow will be trigged to run as well, but it will fail as expected because there are no published releases.
  * Both badges will be broken because there are no releases:
    * [![VPM Package Version](https://img.shields.io/vpm/v/com.vrchat.demo-template?repository_url=https%3A%2F%2Fdustuu.github.io%2Ftemplate-package-unconfigured%2Findex.json)](https://dustuu.github.io/template-package-unconfigured)
    * [![Code Coverage](https://dustuu.github.io/template-package-unconfigured/coverage/badge_linecoverage.svg)](https://dustuu.github.io/template-package-unconfigured/coverage)

* [template-package-skip-tests](https://github.com/dustuu/template-package-skip-tests) shows what happens when only the `PACKAGE_NAME` variable is set, but none of the variables or secrets needed for running Unit Tests are. This is how workflows will run for users who don't opt-in to the new automatic Unit Tests feature, which is likely to be most users.
  * The `Build Release` workflow will skip the `test` job because it is missing the necessary configuration, but will run the `build` job and make a release:
  * ![image](https://github.com/vrchat-community/template-package/assets/101824882/b29be3cb-7667-488f-916b-33d89259c206)
  * The `Build Repo Listing` workflow will be trigged to run and will succeed.
  * The VPM Badge will work because we had a successful release, but the Code Coverage badge will be broken because we did not generate a Code Coverage Report:
    * [![VPM Package Version](https://img.shields.io/vpm/v/com.vrchat.demo-template?repository_url=https%3A%2F%2Fdustuu.github.io%2Ftemplate-package-skip-tests%2Findex.json)](https://dustuu.github.io/template-package-skip-tests)
    * [![Code Coverage](https://dustuu.github.io/template-package-skip-tests/coverage/badge_linecoverage.svg)](https://dustuu.github.io/template-package-skip-tests/coverage)

* [template-package-full](https://github.com/dustuu/template-package-full) shows what happens when all repository variables and secrets are configured properly, and Unit Tests are present. This version uses all available new features.
  * The `Build Release` workflow will pass on all three jobs:
  * ![image](https://github.com/vrchat-community/template-package/assets/101824882/bff44050-a5dc-4ae0-ae6f-ce32d3e345b0)
  * The `Build Repo Listing` workflow will be trigged to run and will succeed, just as before. Additionally, this copies the previously created Code Coverage report onto the GitHub Pages website. This report can then be accessed via the Code Coverage badge in the README.
  * Both badges will be configured properly:
    * [![VPM Package Version](https://img.shields.io/vpm/v/com.vrchat.demo-template?repository_url=https%3A%2F%2Fdustuu.github.io%2Ftemplate-package-full%2Findex.json)](https://dustuu.github.io/template-package-full)
    * [![Code Coverage](https://dustuu.github.io/template-package-full/coverage/badge_linecoverage.svg)](https://dustuu.github.io/template-package-full/coverage)

* [template-package-template-package-fail-tests](https://github.com/dustuu/template-package-fail-tests) shows what happens when all repository variables and secrets are configured properly, but one or more Unit Tests are failing.
  * The `Build Release` workflow will fail because Unit Tests are present and configured to run by the user via repository variables, but failing:
  * ![image](https://github.com/vrchat-community/template-package/assets/101824882/ca7219c0-bbd4-41a9-84d8-556a9c1eaa89)
  * The `Build Repo Listing` workflow will fail as expected because there are no published releases.
  * Both badges will be broken because there are no releases:
    * [![VPM Package Version](https://img.shields.io/vpm/v/com.vrchat.demo-template?repository_url=https%3A%2F%2Fdustuu.github.io%2Ftemplate-package-fail-tests%2Findex.json)](https://dustuu.github.io/template-package-fail-tests)
    * [![Code Coverage](https://dustuu.github.io/template-package-fail-tests/coverage/badge_linecoverage.svg)](https://dustuu.github.io/template-package-fail-tests/coverage)

* [template-package-no-tests](https://github.com/dustuu/template-package-no-tests) shows what happens when all repository variables and secrets are configured properly, but the actual Unit Test files are removed from the repository.
  * The `Build Release` workflow will fail because the user has indicated that Unit Tests are present, but they are not:
  * ![image](https://github.com/vrchat-community/template-package/assets/101824882/121c3c64-eae4-48a3-84fc-ea5aa41808d7)
  * The `Build Repo Listing` workflow will fail as expected because there are no published releases.
  * Both badges will be broken because there are no releases:
    * [![VPM Package Version](https://img.shields.io/vpm/v/com.vrchat.demo-template?repository_url=https%3A%2F%2Fdustuu.github.io%2Ftemplate-package-no-tests%2Findex.json)](https://dustuu.github.io/template-package-no-tests)
    * [![Code Coverage](https://dustuu.github.io/template-package-no-tests/coverage/badge_linecoverage.svg)](https://dustuu.github.io/template-package-no-tests/coverage)

* [template-package-runtime-tests-only-fail](https://github.com/dustuu/template-package-runtime-tests-only-fail) shows what happens when all repository variables and secrets are configured properly, but Unit Tests are only present for testing the package's Editor Scripts.
  * Because `REQUIRED_COVERAGE` is still set to `100`, the `Build Release` workflow will fail due to the Unit Tests no longer covering the Editor Scripts:
  * ![image](https://github.com/vrchat-community/template-package/assets/101824882/d4c67abe-6b23-4276-bf51-ae0c13c551be)
  * The `Build Repo Listing` workflow will fail as expected because there are no published releases.
  * Both badges will be broken because there are no releases:
    * [![VPM Package Version](https://img.shields.io/vpm/v/com.vrchat.demo-template?repository_url=https%3A%2F%2Fdustuu.github.io%2Ftemplate-package-runtime-tests-only-fail%2Findex.json)](https://dustuu.github.io/template-package-runtime-tests-only-fail)
    * [![Code Coverage](https://dustuu.github.io/template-package-runtime-tests-only-fail/coverage/badge_linecoverage.svg)](https://dustuu.github.io/template-package-runtime-tests-only-fail/coverage)

* [template-package-runtime-tests-only](https://github.com/dustuu/template-package-runtime-tests-only) shows the same scenario as [template-package-runtime-tests-only-fail](https://github.com/dustuu/template-package-runtime-tests-only-fail), but this time has `REQUIRED_COVERAGE` set to `0`.
  * The `Build Release` workflow will pass on all three jobs. even without Editor Tests. This is because the new configuration no longer requires full code coverage:
  * ![image](https://github.com/vrchat-community/template-package/assets/101824882/9d54b24d-08e2-49a0-b4a7-e86b7bce55b2)
  * The `Build Repo Listing` workflow will be trigged to run and will succeed.
  * Both badges will be configured properly:
    * [![VPM Package Version](https://img.shields.io/vpm/v/com.vrchat.demo-template?repository_url=https%3A%2F%2Fdustuu.github.io%2Ftemplate-package-runtime-tests-only%2Findex.json)](https://dustuu.github.io/template-package-runtime-tests-only)
    * [![Code Coverage](https://dustuu.github.io/template-package-runtime-tests-only/coverage/badge_linecoverage.svg)](https://dustuu.github.io/template-package-runtime-tests-only/coverage)

* [template-package-editor-tests-only](https://github.com/dustuu/template-package-editor-tests-only) shows the same scenario as [template-package-runtime-tests-only](https://github.com/dustuu/template-package-runtime-tests-only), but with only Editor Tests instead of only Runtime Tests.
  * Just as before, the `Build Release` workflow will pass on all three jobs:
  * ![image](https://github.com/vrchat-community/template-package/assets/101824882/db5787b9-6693-444e-83b5-75831098df81)
  * The `Build Repo Listing` workflow will be trigged to run and will succeed.
  * Both badges will be configured properly:
    * [![VPM Package Version](https://img.shields.io/vpm/v/com.vrchat.demo-template?repository_url=https%3A%2F%2Fdustuu.github.io%2Ftemplate-package-editor-tests-only%2Findex.json)](https://dustuu.github.io/template-package-editor-tests-only)
    * [![Code Coverage](https://dustuu.github.io/template-package-editor-tests-only/coverage/badge_linecoverage.svg)](https://dustuu.github.io/template-package-editor-tests-only/coverage)

Beyond the main features of Unit Tests, Code Coverage, and Repository Variable Configuration, this pull request also includes a few small additional changes.

Previously, zip releases were made with a third-party GitHub Action that used relative paths to back outwards from the package itself:
```yml
- name: Create Zip
  uses: thedoctor0/zip-release@09336613be18a8208dfa66bd57efafd9e2685657
  with:
    type: "zip"
    directory: "Packages/${{env.packageName}}/"
    filename: "../../${{env.zipFile}}" # make the zip file two directories up, since we start two directories in above
```

I have changed this to use the native Bash `zip` command, as well as absolute paths built from `${{ github.workspace }}`.
```yml
- name: Create Package Zip
  working-directory: "${{ env.packagePath }}"
  run: zip -r "${{ github.workspace }}/${{ env.zipFile }}" .
```

This new approach is also used to build the Code Coverage Report zip, if Automatic Unit Testing is enabled.

Finally, names and comments have been added to all workflow steps which did not previously have them. All workflow steps which use other actions via the `uses` keyword have also been set to use their source's commit ID instead of tags, keeping in line with how this was done in most of the original workflows.

This pull request has been built on top of the existing work done in the approved but still-pending PR #11. Therefore, this pull request can be merged in place of or on top of that one with no merge conflicts.