### PR TITLE
Update release.yml - fix yaml parsing error in unitypackage creation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,7 +64,7 @@ jobs:
       
       # Make a UnityPackage version of the Package for release
       - name: Create UnityPackage
-        uses: pCYSl5EDgo/create-unitypackage@cfcd3cf0391a5ef1306342794866a9897c32af0b
+        uses: pCYSl5EDgo/create-unitypackage@b5c57408698b1fab8b3a84d4b67f767b8b7c0be9
         with:
           package-path: ${{ env.unityPackage }}
           include-files: metaList

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,7 +64,7 @@ jobs:
       
       # Make a UnityPackage version of the Package for release
       - name: Create UnityPackage
-        uses: pCYSl5EDgo/create-unitypackage@b5c57408698b1fab8b3a84d4b67f767b8b7c0be9
+        uses: pCYSl5EDgo/create-unitypackage@v1.2.3
         with:
           package-path: ${{ env.unityPackage }}
           include-files: metaList


### PR DESCRIPTION
bump pCYSl5EDgo/create-unitypackage from 1.1 to 1.2 + hotfix
https://github.com/pCYSl5EDgo/create-unitypackage/compare/cfcd3cf...master/

fix es an error in yaml parsing. This got reported by @momo-the-monster (https://github.com/pCYSl5EDgo/create-unitypackage/issues/6) and fixed in the used github action

steps to reproduce:
* download OpenVR Unity XR Package (https://github.com/ValveSoftware/unity-xr-plugin/releases/tag/v1.1.4)
* unpack it into the project
* run ci

current behaviour:
```
file:///home/runner/work/_actions/pCYSl5EDgo/create-unitypackage/cfcd3cf0391a5ef1306342794866a9897c32af0b/node_modules/js-yaml/dist/js-yaml.mjs:1273
  return new exception(message, mark);
         ^
YAMLException: incomplete explicit mapping pair; a key node is missed; or followed by a non-tabulated empty line (15:7)

 12 |   validateReferences: 1
 13 |   platformData:
 14 |   - first:
 15 |       : Any
------------^
 16 |     second:
 17 |       enabled: 0
```